### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.FeedReader.json
+++ b/org.gnome.FeedReader.json
@@ -25,8 +25,6 @@
     "--talk-name=org.freedesktop.secrets"
   ],
   "build-options": {
-    "cflags": "-O2 -g -w",
-    "cxxflags": "-O2 -g",
     "env": {
       "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
       "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.